### PR TITLE
Removes the device sensor class from HCHO

### DIFF
--- a/custom_components/dyson_local/sensor.py
+++ b/custom_components/dyson_local/sensor.py
@@ -372,7 +372,6 @@ class DysonHCHOSensor(DysonSensorEnvironmental):
     _SENSOR_TYPE = "hcho-mg"
     _SENSOR_NAME = "HCHO"
 
-    _attr_device_class = SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS
     _attr_native_unit_of_measurement = CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER
     _attr_state_class = SensorStateClass.MEASUREMENT
 


### PR DESCRIPTION
This is because of a compatibility problem between units for HCHO and the previously selected device sensor class for VOC. HCHO is measured in mg/m3 while VOC is measured in µg/m3. This caused Home Assistant to drop a warning in the logs every time a new Dyson Formaldehyde device was added.

So now we're not using any sensor class for HCHO, which defaults it to None and allows us to use arbitrary units.