### PR TITLE
Add paho-mqtt as a requirement in manifest.json

### DIFF
--- a/custom_components/dyson_local/manifest.json
+++ b/custom_components/dyson_local/manifest.json
@@ -7,5 +7,6 @@
     "documentation": "https://github.com/libdyson-wg/ha-dyson",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/libdyson-wg/ha-dyson/issues",
+    "requirements": ["paho-mqtt"],
     "version": "1.3.0"
 }


### PR DESCRIPTION
Add a requirement on the external package `paho-mqtt` so that Home Assistant will install it when trying to setup ha-dyson for the first time.

I've not put version restrictions in because I don't know what is/isn't compatible, but I found it worked with `paho-mqtt==1.6.1`.