### PR TITLE
[bug-fix] use a default value for device name

### DIFF
--- a/custom_components/dyson_local/config_flow.py
+++ b/custom_components/dyson_local/config_flow.py
@@ -305,12 +305,16 @@ class DysonLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle step to set host."""
         errors = {}
         if info is not None:
+            # NOTE: Sometimes, the device is not named. In these situations,
+            # default to using the unique serial number as the name.
+            name = self._device_info.name or self._device_info.serial
+
             try:
                 data = await self._async_get_entry_data(
                     self._device_info.serial,
                     self._device_info.credential,
                     self._device_info.product_type,
-                    self._device_info.name,
+                    name,
                     info.get(CONF_HOST),
                 )
             except CannotConnect:
@@ -319,7 +323,7 @@ class DysonLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_find"
             else:
                 return self.async_create_entry(
-                    title=self._device_info.name,
+                    title=name,
                     data=data,
                 )
 


### PR DESCRIPTION
### Summary

When attempting to add my HP04 Dyson Pure Hot+Cool device, the HA UI threw a "Unknown error occurred" and refused to connect. After a closer inspection of the logs however, I noticed it _did_ connect, but the failure occurred in the HA stack instead:

```
2023-12-07 22:51:09.847 DEBUG (Thread-7 (_thread_main)) [custom_components.dyson_local.vendor.libdyson.dyson_device] Connected with result code 0
2023-12-07 22:51:09.858 INFO (MainThread) [custom_components.dyson_local.vendor.libdyson.dyson_device] Connected to device <serial-number>
2023-12-07 22:51:10.042 DEBUG (Thread-7 (_thread_main)) [custom_components.dyson_local.vendor.libdyson.dyson_device] New state: {'msg': 'CURRENT-STATE', 'time': '2023-12-08T06:51:10.000Z', 'mode-reason': 'PRC', 'state-reason': 'MODE', 'rssi': '-57', 'channel': '157', 'fqhp': '105336', 'fghp': '75048', 'product-state': {'fpwr': 'ON', 'auto': 'OFF', 'oscs': 'OFF', 'oson': 'OFF', 'nmod': 'OFF', 'rhtm': 'ON', 'fnst': 'FAN', 'ercd': 'NONE', 'wacd': 'NONE', 'nmdv': '0004', 'fnsp': '0001', 'bril': '0002', 'corf': 'OFF', 'cflr': '0099', 'hflr': '0099', 'cflt': 'CARF', 'hflt': 'GHEP', 'sltm': 'OFF', 'osal': '0135', 'osau': '0225', 'ancp': '0090', 'hmod': 'OFF', 'hmax': '2943', 'tilt': 'OK', 'hsta': 'OFF', 'psta': 'OFF', 'fdir': 'ON'}, 'scheduler': {'srsc': '0000000000000000', 'dstv': '0000', 'tzid': '0001'}}
2023-12-07 22:51:10.092 DEBUG (Thread-7 (_thread_main)) [custom_components.dyson_local.vendor.libdyson.dyson_device] New environmental state: {'msg': 'ENVIRONMENTAL-CURRENT-SENSOR-DATA', 'time': '2023-12-08T06:51:10.000Z', 'data': {'tact': '2950', 'hact': '0049', 'pm25': '0009', 'pm10': '0008', 'va10': '0004', 'noxl'
: '0006', 'p25r': '0011', 'p10r': '0014', 'sltm': 'OFF'}}
2023-12-07 22:51:10.095 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 433, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 85, in security_filter_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 100, in forwarded_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 28, in request_context_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 80, in ban_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 236, in auth_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/headers.py", line 31, in headers_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/view.py", line 148, in handle
    result = await handler(request, **request.match_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/decorators.py", line 63, in with_admin
    return await func(self, request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/config/config_entries.py", line 177, in post
    return await super().post(request, flow_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/data_validator.py", line 72, in wrapper
    result = await method(view, request, data, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/data_entry_flow.py", line 110, in post
    result = await self._flow_mgr.async_configure(flow_id, data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 293, in async_configure
    result = await self._async_handle_step(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 422, in _async_handle_step
    result = await self.async_finish_flow(flow, result.copy())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 978, in async_finish_flow
    title=result["title"],
          ~~~~~~^^^^^^^^^
KeyError: 'title'
```

Perplexed, I dug a little deeper by adding a log line [here](https://github.com/libdyson-wg/ha-dyson/blob/ee89dc961ab062dbf0cc24a2fa3b5c1895750aec/custom_components/dyson_local/config_flow.py#L309), and got the following output:

```
2023-12-07 22:51:09.364 DEBUG (MainThread) [custom_components.dyson_local.config_flow] DysonDeviceInfo(active=None, serial='<serial>', name=None, version='ECG2PF.30.06.003.0002', credential='<redacted>, auto_update=True, new_version_available=False, product_type='527')
```

It seems that my device was not named, and consequently, failed to register with an unhelpful error message. However, since the serial number is assumed to exist (guessing by the `async_set_unique_id` call), we can default to the serial number if the name does not exist.

In doing so, this change should be backwards compatible too.

### Testing Done

I applied this change locally, and was able to successfully connect.