### PR TITLE
Update Timer services so that YAML configuration is not required

### DIFF
--- a/custom_components/dyson_local/services.yaml
+++ b/custom_components/dyson_local/services.yaml
@@ -30,5 +30,5 @@ set_timer:
           min: 0
           max: 540
           step: 1
-      unit_of_measurement: "minutes"
+          unit_of_measurement: "minutes"
       required: true

--- a/custom_components/dyson_local/services.yaml
+++ b/custom_components/dyson_local/services.yaml
@@ -30,5 +30,5 @@ set_timer:
           min: 0
           max: 540
           step: 1
-      unit_of_measurement: minutes
+      unit_of_measurement: "minutes"
       required: true

--- a/custom_components/dyson_local/services.yaml
+++ b/custom_components/dyson_local/services.yaml
@@ -17,13 +17,18 @@ set_angle:
 
 set_timer:
   name: Set Timer
-  description: Set the sleep timer.
+  description: Sets, or clears, the timer of a fan (in minutes).
+  target:
+    entity:
+      domain: fan
   fields:
-    entity_id:
-      name: Entity ID
-      description: Name(s) of the entities to set the sleep timer for
-      example: "fan.living_room"
     timer:
-      name: Timer
-      description: The value in minutes to set the timer to, 0 to disable it
-      example: 30
+      name: Minutes
+      description: How many minutes the timer should run for. Set to 0 to disable timer.
+      selector:
+        number:
+          min: 0
+          max: 540
+          step: 1
+      unit_of_measurement: minutes
+      required: true


### PR DESCRIPTION
Partially fixes #90 by no longer requiring using YAML to call the Timer Service (the messages about needing YAML at the bottom are gone now).

We have a minutes selector that only goes within the permissible range (0-540) and an indicator that we are looking at minutes, as opposed to just a random textbox from before.

![image](https://github.com/libdyson-wg/ha-dyson/assets/50791984/ec5b5339-ff4a-403a-91fe-266522cb1580)

The service can only be called on the Fan entity, so we have limited selection to the Fan's domain too. This used to be open to all entities, including the Dyson climate one (which wouldn't have worked).

![image](https://github.com/libdyson-wg/ha-dyson/assets/50791984/cb6e8b26-31e7-45e0-b445-4281d816eb65)

In a future PR, we can add a numeric textbox for this against the device. This will alleviate the need to use the Service in most cases.