### PR TITLE
Add dependency and remove requirement from manifest.json

### DIFF
--- a/custom_components/dyson_local/manifest.json
+++ b/custom_components/dyson_local/manifest.json
@@ -3,10 +3,9 @@
     "name": "Dyson",
     "codeowners": ["@libdyson-wg", "@dotvezz"],
     "config_flow": true,
-    "dependencies": ["zeroconf"],
+    "dependencies": ["mqtt", "zeroconf"],
     "documentation": "https://github.com/libdyson-wg/ha-dyson",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/libdyson-wg/ha-dyson/issues",
-    "requirements": ["paho-mqtt"],
     "version": "1.3.10"
 }


### PR DESCRIPTION
We have a dependency on MQTT that needs to be initialised before we start reaching out to the device. We also don't need to explictly call out paho-mqtt as a dependency as it is required by HA more generally and is not specific to Dyson.