### PR TITLE
Fix reloading the integration from hanging

### DIFF
--- a/custom_components/dyson_local/__init__.py
+++ b/custom_components/dyson_local/__init__.py
@@ -178,21 +178,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Dyson local."""
-    device = hass.data[DOMAIN][DATA_DEVICES][entry.entry_id]
-    ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in _async_get_platforms(device)
-            ]
-        )
-    )
-    if ok:
+    device: DysonDevice = hass.data[DOMAIN][DATA_DEVICES][entry.entry_id]
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, _async_get_platforms(device))
+
+    if unload_ok:
         hass.data[DOMAIN][DATA_DEVICES].pop(entry.entry_id)
         hass.data[DOMAIN][DATA_COORDINATORS].pop(entry.entry_id)
         await hass.async_add_executor_job(device.disconnect)
         # TODO: stop discovery
-    return ok
+    return unload_ok
 
 
 @callback

--- a/custom_components/dyson_local/manifest.json
+++ b/custom_components/dyson_local/manifest.json
@@ -5,9 +5,8 @@
     "config_flow": true,
     "dependencies": ["mqtt", "zeroconf"],
     "documentation": "https://github.com/libdyson-wg/ha-dyson",
-    "import_executor": true,
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/libdyson-wg/ha-dyson/issues",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "import_executor": true
 }

--- a/custom_components/dyson_local/manifest.json
+++ b/custom_components/dyson_local/manifest.json
@@ -5,6 +5,7 @@
     "config_flow": true,
     "dependencies": ["mqtt", "zeroconf"],
     "documentation": "https://github.com/libdyson-wg/ha-dyson",
+    "import_executor": true,
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/libdyson-wg/ha-dyson/issues",
     "version": "1.4.2"


### PR DESCRIPTION
When doing reload on the integration, it would always hang and all entities would become unavailable. This would require homeassistant to completely reboot before the integration would work again. Changing it to use the built in platforms unload function has fixed this behavior.