### PR TITLE
Add a DysonFilterLifePercentage class for the Pure Cool link

### DIFF
--- a/custom_components/dyson_local/sensor.py
+++ b/custom_components/dyson_local/sensor.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
             entities.extend(
                 [
                     DysonFilterLifeSensor(device, name),
+                    DysonFilterLifeSensorPercentage(device, name),
                     DysonParticulatesSensor(coordinator, device, name),
                 ]
             )
@@ -152,6 +153,22 @@ class DysonFilterLifeSensor(DysonSensor):
     def native_value(self) -> int:
         """Return the state of the sensor."""
         return self._device.filter_life
+
+
+class DysonFilterLifeSensorPercentage(DysonSensor):
+    """Dyson filter life sensor (in percentage) for Pure Cool Link."""
+
+    _SENSOR_TYPE = "filter_life_percentage"
+    _SENSOR_NAME = "Filter Life Percentage"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:filter-outline"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_suggested_display_precision = 0
+
+    @property
+    def native_value(self) -> float:
+        """Return the state of the sensor calculated to a %."""
+        return (self._device.filter_life / 4300) * 100
 
 
 class DysonCarbonFilterLifeSensor(DysonSensor):


### PR DESCRIPTION
You might not like this as it's a calculated sensor value and not a raw value, and you can make calculated sensor values with the templating integration -- this is fair, cause it makes me a little squishy myself.

But I didn't like either option provided by the integration. Defining the sensor in `configuration.yaml` means it can't be added to the air purifier device, and defining the sensor using the integration's UI tool lets you add the sensor to the air purifier device but it's in the Sensors section not the Diagnostic section. I didn't like having a sensor that should be a diagnostic out of place, so I did this for myself, and thought I'd at least give you the opportunity to decide if you think it'd be useful for anyone else.

I have 3 of these that seem to confirm that the math here matches the math being used in how the % is displayed in the official Dyson app.