### PR TITLE
Implemented fan preset icons

### DIFF
--- a/custom_components/dyson_local/fan.py
+++ b/custom_components/dyson_local/fan.py
@@ -45,8 +45,8 @@ SET_TIMER_SCHEMA = {
     vol.Required(ATTR_TIMER): cv.positive_int,
 }
 
-PRESET_MODE_AUTO = "Auto"
-PRESET_MODE_NORMAL = "Normal"
+PRESET_MODE_AUTO = "auto"
+PRESET_MODE_NORMAL = "normal"
 
 SUPPORTED_PRESET_MODES = [PRESET_MODE_AUTO, PRESET_MODE_NORMAL]
 
@@ -87,6 +87,8 @@ async def async_setup_entry(
 
 class DysonFanEntity(DysonEntity, FanEntity):
     """Dyson fan entity base class."""
+
+    _attr_translation_key = "dyson_fan"
 
     _enable_turn_on_off_backwards_compatibility = False
 

--- a/custom_components/dyson_local/icons.json
+++ b/custom_components/dyson_local/icons.json
@@ -6,8 +6,7 @@
           "preset_mode": {
             "default": "mdi:fan",
             "state": {
-              "auto": "mdi:fan-auto",
-              "normal": "mdi:fan"
+              "auto": "mdi:fan-auto"
             }
           }
         }

--- a/custom_components/dyson_local/icons.json
+++ b/custom_components/dyson_local/icons.json
@@ -1,0 +1,17 @@
+{
+  "entity": {
+    "fan": {
+      "dyson_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:fan",
+            "state": {
+              "auto": "mdi:fan-auto",
+              "normal": "mdi:fan"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/dyson_local/translations/en.json
+++ b/custom_components/dyson_local/translations/en.json
@@ -71,5 +71,19 @@
     "abort": {
       "already_configured": "Device already configured"
     }
+  },
+  "entity": {
+    "fan": {
+      "dyson_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "normal": "Normal"
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request should resolve #168 as it bothered me. To be honest I used ChatGPT as I was to lazy to go through the documentation myself, but I checked it and everything should be according to [home assistant developer documentation](https://developers.home-assistant.io/docs/core/entity/#icons).

This is actually my first contribution to a public project! So please feel free to comment if I should do something different or could improve something!

Edit 1: 
This of course breaks existing automations which change the preset as the variable has changed. But this is the only thing I found so far. Tested with Dyson Pure Humidify + Cool Gen 1.