### PR TITLE
Remove BATTERY feature from vacuum entity

### DIFF
--- a/custom_components/dyson_local/vacuum.py
+++ b/custom_components/dyson_local/vacuum.py
@@ -34,7 +34,6 @@ SUPPORTED_FEATURES = (
     | VacuumEntityFeature.FAN_SPEED
     | VacuumEntityFeature.STATUS
     | VacuumEntityFeature.STATE
-    | VacuumEntityFeature.BATTERY
 )
 
 DYSON_STATUS = {


### PR DESCRIPTION
Detected that custom integration 'dyson_local' is setting the battery supported feature which has been deprecated. Integration dyson_local should remove this as part of migrating the battery level and icon to a sensor. This will stop working in Home Assistant 2026.8, please create a bug report at https://github.com/libdyson-wg/ha-dyson/issues